### PR TITLE
PLAFM-3036: Change employee restriction logic

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -61,7 +61,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Employ
         protected Boolean doInBackground(Void... voids) {
             try {
                 Employee employee = cloverEmployees.getEmployee();
-                if (employee != null && employee.getRole() == AccountRole.ADMIN) {
+                if (employee != null && employee.getRole() != AccountRole.EMPLOYEE) {
                     return true;
                 }
             } catch (Exception e) {
@@ -355,7 +355,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements Employ
     public void onActiveEmployeeChanged(Employee employee) {
         if (employee == null) {
             finish();
-        } else if (employee.getRole() != AccountRole.ADMIN) {
+        } else if (employee.getRole() == AccountRole.EMPLOYEE) {
             finish();
         }
     }


### PR DESCRIPTION
Logic is supported to allowed if the user is not the employee role... so allow manager, admin ... as opposed to what I did originally which is allow is the user is admin, which disallows manager.